### PR TITLE
Remove assertions that fail on recent Python versions

### DIFF
--- a/ast_scope/annotator.py
+++ b/ast_scope/annotator.py
@@ -222,13 +222,6 @@ class AnnotateScope(GroupSimilarConstructsVisitor):
         subscope = self.create_subannotator(
             IntermediateClassScope(class_node, self.scope, self.class_binds_near)
         )
-        assert class_node._fields == (
-            "name",
-            "bases",
-            "keywords",
-            "body",
-            "decorator_list",
-        )
         visit_all(subscope, class_node.body)
         visit_all(
             self, class_node.bases, class_node.keywords, class_node.decorator_list

--- a/ast_scope/pull_scope.py
+++ b/ast_scope/pull_scope.py
@@ -90,13 +90,6 @@ class PullScopes(GroupSimilarConstructsVisitor):
         scope = self.pull_scope(node)
         if node not in self.node_to_corresponding_scope:
             self.node_to_corresponding_scope[node] = ClassScope(node, scope)
-        assert node._fields == (
-            "name",
-            "bases",
-            "keywords",
-            "body",
-            "decorator_list",
-        )
         visit_all(self, node.bases, node.keywords, node.decorator_list)
         scope.add_class(node, self.node_to_corresponding_scope[node])
         visit_all(self, node.body)


### PR DESCRIPTION
Addresses the issue raised in #9 by removing the assertions that vary across Python versions